### PR TITLE
Separate evaluation from solving

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,17 +20,19 @@ Possible types of changes are:
 Unreleased
 ----------
 
-Changed
-'''''''
-- simplify ``op`` decorator
-- simplify default implementation of ``Op.__repr__`
-  Unreleased
-  ----------
-  
+Deprecated
+''''''''''
+- support for unresolved output variables in ``session.evaluate``, use ``sessions.solve`` for that purpose
+- support for arguments of type Variable in ``Op.__call__``, use ``Op.op`` instead
+
 Changed
 '''''''
 - simplify ``op`` decorator
 - simplify default implementation of ``Op.__repr__``
+
+Added
+'''''
+- method ``Op.op`` to be used in place of direct invocation of an Op instance when building a graph
 
 
 1.0.1 - 07.10.2020

--- a/paragraph/session.py
+++ b/paragraph/session.py
@@ -3,7 +3,7 @@ import warnings
 
 from concurrent.futures import Executor, Future
 from itertools import filterfalse
-from typing import Dict, Any, List, Generator, Iterable, Optional
+from typing import Dict, Any, List, Generator, Iterable, Optional, Tuple
 from collections import defaultdict, deque
 from contextlib import contextmanager
 
@@ -77,7 +77,7 @@ def _count_usages(output: Iterable[Variable]) -> Dict[Variable, int]:
     return usage_counts
 
 
-def _get_arguments(var: Variable, cache: Dict[Variable, Any], usage_counts: Dict[Variable, int], output):
+def _get_arguments(var: Variable, cache: Dict[Variable, Any], usage_counts: Dict[Variable, int], output) -> Tuple[List, Dict]:
     arguments = {}
     for arg, dep in var.dependencies.items():
         usage_counts[dep] -= 1

--- a/paragraph/session.py
+++ b/paragraph/session.py
@@ -12,6 +12,11 @@ from paragraph.types import Variable, Requirement, Op
 
 @contextmanager
 def eager_mode():
+    """Activate eager mode within a context manager.
+
+    In eager mode, the method ``Op.op`` is replaced with the direct invocation of the underlying method ``Op._run``. In this mode, no variable is emitted,
+    allowing to test a computation graph without ever calling ``session.evaluate``.
+    """
     op = Op.op
     Op.op = lambda self, *a, **k: self._run(*a, **k)
     yield

--- a/paragraph/tests/test_session.py
+++ b/paragraph/tests/test_session.py
@@ -3,7 +3,7 @@ import pytest
 from concurrent.futures.thread import ThreadPoolExecutor
 
 from paragraph.types import Variable
-from paragraph.session import eager_mode, traverse_fw, traverse_bw, evaluate, solve_requirements, apply
+from paragraph.session import eager_mode, traverse_fw, traverse_bw, evaluate, solve_requirements, apply, solve
 from paragraph.tests.test_types import MockReq, mock_op
 
 
@@ -85,6 +85,55 @@ class TestEvaluate:
         operation = graph.output[1].op
 
         assert res[0] == "op0_return_value"
+        assert not operation._run.called
+
+    @staticmethod
+    def test_deprecation_if_evaluating_with_incomplete_arguments(graph):
+        with pytest.deprecated_call():
+            res = evaluate([graph.output[0]], args={})
+
+    @staticmethod
+    def test_no_deprecation_if_evaluating_with_complete_arguments(graph):
+        with pytest.warns(None) as record:
+            res = evaluate([graph.output[0]], args={graph.input: 0})
+
+        assert len(record) == 0
+
+
+class TestSolve:
+    @staticmethod
+    def test_sequential_solve_is_correct(graph):
+        res = solve(graph.output, args={graph.input: "input_value"})
+
+        assert isinstance(res[0], Variable)
+        assert res[0].args == {"arg": "input_value"}
+        assert res[0].dependencies == {}
+        assert isinstance(res[1], Variable)
+        assert res[1].args == {0: "input_value"}
+        assert res[1].dependencies == {"arg1": res[0]}
+
+        graph.output[0].op._run.assert_not_called()
+        graph.output[1].op._run.assert_not_called()
+
+    @staticmethod
+    def test_parallel_solve_is_correct(graph, thread_pool_executor):
+        res = solve(graph.output, args={graph.input: "input_value"}, executor=thread_pool_executor)
+
+        assert isinstance(res[0], Variable)
+        assert res[0].args == {"arg": "input_value"}
+        assert res[0].dependencies == {}
+        assert isinstance(res[1], Variable)
+        assert res[1].args == {0: "input_value"}
+        assert res[1].dependencies == {"arg1": res[0]}
+
+        graph.output[0].op._run.assert_not_called()
+        graph.output[1].op._run.assert_not_called()
+
+    @staticmethod
+    def test_solve_is_lazy(graph):
+        res = evaluate([graph.output[0]], args={graph.input: "input_value"})
+        operation = graph.output[1].op
+
         assert not operation._run.called
 
 

--- a/paragraph/tests/test_session.py
+++ b/paragraph/tests/test_session.py
@@ -131,7 +131,7 @@ class TestSolve:
 
     @staticmethod
     def test_solve_is_lazy(graph):
-        res = evaluate([graph.output[0]], args={graph.input: "input_value"})
+        _ = evaluate([graph.output[0]], args={graph.input: "input_value"})
         operation = graph.output[1].op
 
         assert not operation._run.called

--- a/paragraph/tests/test_session.py
+++ b/paragraph/tests/test_session.py
@@ -90,12 +90,12 @@ class TestEvaluate:
     @staticmethod
     def test_deprecation_if_evaluating_with_incomplete_arguments(graph):
         with pytest.deprecated_call():
-            res = evaluate([graph.output[0]], args={})
+            _ = evaluate([graph.output[0]], args={})
 
     @staticmethod
     def test_no_deprecation_if_evaluating_with_complete_arguments(graph):
         with pytest.warns(None) as record:
-            res = evaluate([graph.output[0]], args={graph.input: 0})
+            _ = evaluate([graph.output[0]], args={graph.input: 0})
 
         assert len(record) == 0
 

--- a/paragraph/tests/test_types.py
+++ b/paragraph/tests/test_types.py
@@ -146,5 +146,3 @@ class TestOpClass:
         result = operation.op(argument)
 
         assert isinstance(result, Variable)
-
-

--- a/paragraph/types.py
+++ b/paragraph/types.py
@@ -51,10 +51,10 @@ class Variable:
 
         return "{}({})".format(self.op, ", ".join(pos_arg_strings + kw_arg_strings))
 
-    def isinput(self):
+    def isinput(self) -> bool:
         return len(self.args) + len(self.dependencies) == 0
 
-    def isdependent(self):
+    def isdependent(self) -> bool:
         return len(self.dependencies) > 0
 
 
@@ -208,7 +208,7 @@ class Op:
         return Variable(op=self, args=static_args, dependencies=var_args)
 
 
-def op(func: Callable) -> Callable:
+def op(func: Callable) -> Op:
     """Wraps a function within an Op object.
 
     The returned function accepts arguments of type Variable everywhere in its signature, in addition to the types accepted by the decorated function. In

--- a/paragraph/types.py
+++ b/paragraph/types.py
@@ -4,7 +4,7 @@ import warnings
 
 from concurrent.futures import Future
 from itertools import chain
-from typing import Callable, Dict, Optional, Tuple, List, Any, Iterable, Union, TypeVar
+from typing import Callable, Dict, Optional, Tuple, List, Any, Iterable, Union
 from abc import ABC, abstractmethod
 
 

--- a/paragraph/types.py
+++ b/paragraph/types.py
@@ -8,9 +8,6 @@ from typing import Callable, Dict, Optional, Tuple, List, Any, Iterable, Union, 
 from abc import ABC, abstractmethod
 
 
-T = TypeVar("T")
-
-
 @attr.s(eq=False, repr=False, frozen=True)
 class Variable:
     """A generic :term:`variable`.

--- a/paragraph/types.py
+++ b/paragraph/types.py
@@ -1,10 +1,14 @@
 """Class definitions supporting the computation graph"""
 import attr
+import warnings
 
 from concurrent.futures import Future
 from itertools import chain
-from typing import Callable, Dict, Optional, Tuple, List, Any, Iterable, Union
+from typing import Callable, Dict, Optional, Tuple, List, Any, Iterable, Union, TypeVar
 from abc import ABC, abstractmethod
+
+
+T = TypeVar("T")
 
 
 @attr.s(eq=False, repr=False, frozen=True)
@@ -31,9 +35,10 @@ class Variable:
 
     @name.validator
     def _name_only_independent_variable(self, _, value):
-        if len(self.dependencies) > 0 and value is not None:
+        num_args = len(self.dependencies) + len(self.args)
+        if num_args > 0 and value is not None:
             raise ValueError("Only independent variables can be given a name.")
-        if len(self.dependencies) == 0 and value is None:
+        if num_args == 0 and value is None:
             raise ValueError("Independent variables must be given a name.")
 
     def __repr__(self):
@@ -48,6 +53,12 @@ class Variable:
         kw_arg_strings = [f"{arg}={val}" for arg, val in args.items()]
 
         return "{}({})".format(self.op, ", ".join(pos_arg_strings + kw_arg_strings))
+
+    def isinput(self):
+        return len(self.args) + len(self.dependencies) == 0
+
+    def isdependent(self):
+        return len(self.dependencies) > 0
 
 
 @attr.s
@@ -165,7 +176,11 @@ class Op:
         return type(req)()
 
     def __call__(self, *args, **kwargs):
-        """Wraps an instance method to work within the computational graph"""
+        """Execute the operation, first awaiting future arguments.
+
+        .. warning::
+            The support of arguments of type Variable will be dropped in version 2.0, use Op.op() below when building a graph.
+        """
         all_args = self._collect_args(args, kwargs)
         var_args = {arg: var for arg, var in all_args.items() if isinstance(var, Variable)}
 
@@ -174,6 +189,23 @@ class Op:
             pos_args, kw_args = Op.split_args(all_args)
             return self._run(*pos_args, **kw_args)
 
+        # The code below is scheduled for deletion
+        warnings.warn("Direct invocation of an Op instance with arguments of type Variable is deprecated and scheduled for removal in version 2.0."
+                      "Use Op.op() instead.",
+                      DeprecationWarning)
+
+        static_args = {arg: val for arg, val in all_args.items() if not isinstance(val, Variable)}
+        return Variable(op=self, args=static_args, dependencies=var_args)
+
+    def op(self, *args, **kwargs) -> Variable:
+        """Define a variable as the result of applying the op to the arguments provided.
+
+        While this method always returns a Variable instance, it accepts:
+          - _concrete_ arguments of the type expected by ``_run`` at the same position/for the same keyword,
+          - Variable instances that resolve to a value of the expected type.
+        """
+        all_args = self._collect_args(args, kwargs)
+        var_args = {arg: var for arg, var in all_args.items() if isinstance(var, Variable)}
         static_args = {arg: val for arg, val in all_args.items() if not isinstance(val, Variable)}
 
         return Variable(op=self, args=static_args, dependencies=var_args)


### PR DESCRIPTION
This changeset introduces a new function, ``session.solve``, which
always returns a list of Variable instances (possibly resolved ones,
that is Variable instances with no dependencies). In contrast,
``sessions.evaluate`` now returns non-variable values or warns for the
deprecation of the support for evaluating unresolved variables.

A couple of code factorization is also including in this changeset.