### PR TITLE
Assorted fixes of the documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ dist
 
 # Keeping Pipfile.lock out of version control as multiple versions of Python are being targeted
 Pipfile.lock
+

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,12 +14,16 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('../../'))
 
+# -- Apidoc ------------------------------------------------------------------
+
+from sphinx.ext import apidoc
+sys.path.insert(0, os.path.abspath('../../'))
+apidoc.main(['--force', '--separate', '-o', './apidoc', '../../paragraph'])
 
 # -- Project information -----------------------------------------------------
 
-project = 'othoz-paragraph'
+project = 'paragraph'
 copyright = '2019, Othoz GmbH'
 author = 'Othoz GmbH'
 
@@ -44,8 +48,7 @@ extensions = [
     # Typehints are currently deactivated as this would require to maintain a separate requirements.txt for readthedocs.
     # readthedocs will most likely support Pipfiles in the future, then we can reactivate this feature
     # https://github.com/readthedocs/readthedocs.org/issues/3181
-    # 'sphinx.ext.napoleon',  # must be loaded before 'sphinx_autodoc_typehints' according to https://github.com/agronholm/sphinx-autodoc-typehints
-    # 'sphinx_autodoc_typehints',
+    'sphinx.ext.napoleon',  # must be loaded before 'sphinx_autodoc_typehints' according to https://github.com/agronholm/sphinx-autodoc-typehints
     # 'sphinx.ext.mathjax'
 ]
 
@@ -123,7 +126,7 @@ html_theme_options = {
 # -- Options for HTMLHelp output ---------------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'othoz-paragraphdoc'
+htmlhelp_basename = 'paragraphdoc'
 
 # -- Extension configuration -------------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,7 +19,7 @@ import sys
 
 from sphinx.ext import apidoc
 sys.path.insert(0, os.path.abspath('../../'))
-apidoc.main(['--force', '--separate', '-o', './apidoc', '../../paragraph', '../../paragraph/tests/*'])
+apidoc.main(['--force', '-M', '-e', '-E', '-T', '-o', './apidoc', '../../paragraph', '../../paragraph/tests/*'])
 
 # -- Project information -----------------------------------------------------
 
@@ -75,7 +75,7 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path .
-exclude_patterns = []
+exclude_patterns = ["apidoc/paragraph.rst"]
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,7 +19,7 @@ import sys
 
 from sphinx.ext import apidoc
 sys.path.insert(0, os.path.abspath('../../'))
-apidoc.main(['--force', '--separate', '-o', './apidoc', '../../paragraph'])
+apidoc.main(['--force', '--separate', '-o', './apidoc', '../../paragraph', '../../paragraph/tests/*'])
 
 # -- Project information -----------------------------------------------------
 
@@ -49,6 +49,7 @@ extensions = [
     # readthedocs will most likely support Pipfiles in the future, then we can reactivate this feature
     # https://github.com/readthedocs/readthedocs.org/issues/3181
     'sphinx.ext.napoleon',  # must be loaded before 'sphinx_autodoc_typehints' according to https://github.com/agronholm/sphinx-autodoc-typehints
+    'sphinx_autodoc_typehints',
     # 'sphinx.ext.mathjax'
 ]
 

--- a/docs/source/docs.rst
+++ b/docs/source/docs.rst
@@ -11,6 +11,10 @@ When the arguments passed to `paragraph.session.evaluate` are insufficient to re
 dependency of the output variable is left uninitialized), the value returned for the output variable is simply another variable. This new variable has in
 general fewer dependencies, for dependencies fully resolved upon evaluation are replaced by their values.
 
+.. note::
+  The ambiguity on the type returned by ``paragraph.session.evaluate`` will be lifted in version 2.0. From there on, ``paragraph.session.evaluate`` will raise
+  in situations such as described above. The support for partial evaluation will however be continued using the new function ``paragraph.session.solve``.
+
 
 Mapping over inputs
 '''''''''''''''''''

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,8 +7,9 @@
 .. toctree::
    :caption: API Reference
    :maxdepth: 3
+   :glob:
 
-   apidoc/modules
+   apidoc/*
 
 .. toctree::
    :caption: Changelog

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,17 +5,18 @@
    docs
 
 .. toctree::
+   :caption: API Reference
+   :maxdepth: 3
+
+   apidoc/modules
+
+.. toctree::
    :caption: Changelog
    :maxdepth: 1
 
    changelog
 
-.. toctree::
-   :caption: API Documentation
-   :maxdepth: 3
-
-   apidoc/modules
-
+.
 Indices and tables
 ==================
 

--- a/paragraph/session.py
+++ b/paragraph/session.py
@@ -1,4 +1,9 @@
-"""Algorithms for traversing and evaluating a computation graph."""
+"""
+Session
+*******
+
+*Algorithms for traversing, solving and evaluating computation graphs*
+"""
 import warnings
 
 from concurrent.futures import Executor, Future

--- a/paragraph/types.py
+++ b/paragraph/types.py
@@ -1,4 +1,9 @@
-"""Class definitions supporting the computation graph"""
+"""
+Classes and decorator
+*********************
+
+*Class definitions supporting the computation graphs.*
+"""
 import attr
 import warnings
 


### PR DESCRIPTION
This changeset adds an invocation of sphinx-apidoc to Sphinx'
``conf.py`` to ensure the API documentation actually gets generated for
inclusion.

Also included in this commit is a number of minor updates to the static
documentation files.