### PR TITLE
Make ``Op.thread_safe`` a keyword-only argument of ``Op.__init__``

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,15 @@ Possible types of changes are:
 - ``Security`` in case of vulnerabilities
 
 
+1.2.0 - Unreleased
+------------------
+
+Changed
+'''''''
+- attribute ``Op.thread_safe`` is now a keyword-only argument of ``__init__`` to permit attributes without default values in derived classes.
+
+
+
 1.1.1 - 23.01.2020
 ------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,7 +25,6 @@ Changed
 - attribute ``Op.thread_safe`` is now a keyword-only argument of ``__init__`` to permit attributes without default values in derived classes.
 
 
-
 1.1.1 - 23.01.2020
 ------------------
 

--- a/paragraph/types.py
+++ b/paragraph/types.py
@@ -130,7 +130,7 @@ class Op:
     Attributes:
         thread_safe: If False, the op is always executed in the main thread. Defaults to True.
     """
-    thread_safe = attr.ib(type=bool, default=True)
+    thread_safe = attr.ib(type=bool, default=True, kw_only=True)
 
     def __repr__(self):
         """Return the operation name


### PR DESCRIPTION
The purpose of this change is to permit derived Op classes to introduce
additional attributes without defaults. This is so far prevented by the
rule that arguments without defaults must appear before any argument
with a default.