### PR TITLE
Update PyPI token for travis-ci.com

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,19 @@
 sudo: false
 language: python
-
 python:
-  - "3.6"
-
+- '3.6'
 install:
-  - pip install pipenv
-  - pipenv install --dev --three
-
+- pip install pipenv
+- pipenv install --dev --three
 script:
-  - flake8
-  - pytest --cov=paragraph --cov-branch --cov-report=xml
-
+- flake8
+- pytest --cov=paragraph --cov-branch --cov-report=xml
 deploy:
   provider: pypi
-  user: "__token__"
+  user: __token__
   password:
-    secure: "GVdGfpmX8+8wMflttvPkqRJW2yX4YAfF54QwYHglrnFRlVg21g2ywO9rlttQFgeYdBSqANDEE68qykRmzSGql3THNF9FP/UhkwCRpwDKFfFUcZigVXiu8EPrAeNq1sBthZSe9/Zc+kQv4XqaHixAjyarmacRLXBaHv/lCxlXCnYL1g0m5WJD7XeCG6eCDB5/gnGl7beLlt+s4n54Mpwl7S1jueo3UZXfEjavQTxlb3RXgaO45wtYHzvTMqvmkhsWsetFlXW+k4qDhGDmfuJi23+lDWPIJCldF22o8r/mGz7ofOxGXVdidCmSWNdC6IAe6FD0iOYUIPrquOAox86Swaf6KIUD8l5BGA62DNl3Zd6EKGK1j2XAEtWDXiCUJr+4TwuMAWgy3m7h989/bsxqOs22JU4BAbVTivHfYSss9OpoWs0O8Q4LIIjwg8Fcr8p8TWB4AenO4LfIU/lNT37oaS/HOL37fwJsiC0VUP0m3OYYXhYA33dIOtFClGYd4UVbCaIUKrjDZMCrMxWBtd8OmajL7nZs+CUKj3z5VhKjWmcCwBjj8Aax95dQ5T2eT8CItTigAlBWnUSuwDhYcNTlw2iAnUfeI1JGpFnQKL6WC5qv6dEcPLl7IGwOsrZ0SL/xMt2dRCGDCzBMagwylHq/j9Kus63/N+HoYJj3WHMqqYQ="
+    secure: W7L9544a0ZLA3v4BfzNgLDNRnTfRHE86rdvgyekdmgBnPhys5qYpYPCFkVVC68/tbxV4Hlrmkn2bnHJd0OfWGjOqWAtbJYJyizhnLp1JVIbdN547ZZp1u/sVlbFqsonvIRz0oV7COjxWVOzkGMnY/0tyqpdR0bIZn1653l4fAs+tqMm9cvXqJ8S4ulRQGzqO418B1WStMuGAj+JWciS0uhqDJdPW135yCx0KtYs7wr3ui37368pXF/SyFMGNxUT5I85cnHwSyF8p4LpSQmXOoQyG6u9G/Vl2AwPgsorrhJ6vSe5pEgK945Bz6SvRGzk1El99HubHxnMBbkXpEotKyTQfJESgvOT4QuPn5ODwtB7NOxebHSK8+rsSOFMoBGdDvhbNj/oXAp1Unm9auywo0cjVxL1qZcuSoD89g60VFC0YkVu0KAuvyzkQE/yopn19V2QPAMpfE3LZq/sxdUPahNd9yhzmIr6A77tO74D2bu6uajYbWIvHfCQIK1HNVhg75REA0pfDxuELAsahlSIbqJjQEuYxUTRKmVWrzsa9DC1hsReIGY6VnF+SEDiKkF7DyNsidOKNoVgvs4pKiQRjjIJtyATd+QIeY50VZRqXRtMMBXe+u3YCa4chXvT4QCnjP8b0FbGQLr08nDLk/pCMt46+ve7fhEb8tFi83c8auz0=
   on:
     tags: true
-
 after_success:
-  - python-codacy-coverage -r coverage.xml
+- python-codacy-coverage -r coverage.xml


### PR DESCRIPTION
Travis encrypts the PyPI token differently for the .org and .com
services. Moving to the .com service therefore invalidated the existing
token. This changeset introduces the updated token.