### PR TITLE
Add transparent wrapping of arbitrary modules

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,15 @@ Possible types of changes are:
 - ``Security`` in case of vulnerabilities
 
 
+1.3.0 - Unreleased
+------------------
+
+Added
+'''''
+- The ``paragraph.wrap`` virtual package. Any installed module can be imported under that package, resulting in all top-level callables being wrapped as
+paragraph ops.
+
+
 1.2.1 - 05.02.2020
 ------------------
 

--- a/paragraph/__init__.py
+++ b/paragraph/__init__.py
@@ -1,2 +1,8 @@
+import sys as _sys
+
+from paragraph._wrapper import WrappedModuleFinder
+
 from paragraph.types import Variable, op  # noqa: F401
 from paragraph.session import evaluate, apply, solve, solve_requirements  # noqa: F401
+
+_sys.meta_path.append(WrappedModuleFinder)

--- a/paragraph/_wrapper.py
+++ b/paragraph/_wrapper.py
@@ -17,11 +17,13 @@ from paragraph.types import op
 
 
 class WrappedModuleFinder:
-    """
-    Data package module loader finder. This class sits on `sys.meta_path` and returns the
-    loader it knows for a given path, if it knows a compatible loader.
-    """
+    """Paragraph virtual package finder
 
+    A module finder class that detects the ``paragraph.wrap`` prefix of the virtual package. It delegates the import of any module under that prefix to the
+    WrappedModuleLoader class below.
+
+    This class must be appended to ``sys.meta_path`` to be considered by Python's import system.
+    """
     @classmethod
     def find_spec(cls, fullname, path=None, target=None):
         """
@@ -34,6 +36,12 @@ class WrappedModuleFinder:
 
 
 class WrappedModuleLoader:
+    """Paragraph virtual package loader
+
+    A module loader class that imports modules under the ``paragraph.wrap`` prefix. This loader proceeds as follows:
+    - import the underlying module (i.e. the module whose qualified name follows the prefix ``paragraph.wrap``) locally,
+    - populate the virtual module with the callables in the underlying module wrapped by ``paragraph.op``.
+    """
     @classmethod
     def create_module(cls, spec):
         return None
@@ -41,6 +49,7 @@ class WrappedModuleLoader:
     @classmethod
     def exec_module(cls, module):
         if module.__name__ == "paragraph.wrap":
+            # module.__path__ is required, but may be just an empty list
             module.__path__ = []
             return module
 

--- a/paragraph/_wrapper.py
+++ b/paragraph/_wrapper.py
@@ -1,0 +1,57 @@
+"""A module loader wrapping all callables as ops on import
+
+This module defines a module finder/loader pair defining a virtual package ``paragraph.wrap``. Any installed module can be imported within this virtual
+package, resulting in all the callables defined in it to be wrapped by the ``paragraph.op`` decorator.
+
+Example:
+    >>> from paragraph.wrap.operator import add
+    >>> import paragraph as pg
+    >>> x = pg.Variable("x")
+    >>> y = add.op(x, 2)
+"""
+from importlib import import_module
+from importlib.machinery import ModuleSpec
+from typing import Callable
+
+from paragraph.types import op
+
+
+class WrappedModuleFinder:
+    """
+    Data package module loader finder. This class sits on `sys.meta_path` and returns the
+    loader it knows for a given path, if it knows a compatible loader.
+    """
+
+    @classmethod
+    def find_spec(cls, fullname, path=None, target=None):
+        """
+        This functions is what gets executed by the loader.
+        """
+        if fullname.startswith("paragraph.wrap"):
+            return ModuleSpec(fullname, WrappedModuleLoader())
+
+        return None
+
+
+class WrappedModuleLoader:
+    @classmethod
+    def create_module(cls, spec):
+        return None
+
+    @classmethod
+    def exec_module(cls, module):
+        if module.__name__ == "paragraph.wrap":
+            module.__path__ = []
+            return module
+
+        inner_module_path = module.__name__.split(".", maxsplit=2)[2]
+        inner_module = import_module(inner_module_path)
+
+        for func_name in dir(inner_module):
+            func = getattr(inner_module, func_name)
+            if isinstance(func, Callable):
+                module.__dict__[func_name] = op(func)
+
+        module.__path__ = []
+
+        return module


### PR DESCRIPTION
This changeset introduces a module finder/loader pair, which allows
to import arbitrary modules with all top-level callables wrapped as
paragraph operations.