### PR TITLE
Reraise exceptions raised by ``Op.__call__``

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,7 +23,13 @@ Possible types of changes are:
 Added
 '''''
 - The ``paragraph.wrap`` virtual package. Any installed module can be imported under that package, resulting in all top-level callables being wrapped as
-paragraph ops.
+  paragraph ops.
+
+Changed
+'''''''
+- If the ``__call__`` method of an ``Op`` instance raises during execution of ``paragraph.session.evaluate``, the latter catches the exception, raises a
+  ``RuntimeError`` indicating the variable whose evaluation failed, and sets the original exception as the direct cause of the ``RuntimeError``. Note that
+  this currently only applies to single-threaded evaluations.
 
 
 1.2.1 - 05.02.2020

--- a/paragraph/session.py
+++ b/paragraph/session.py
@@ -142,7 +142,10 @@ def evaluate(output: Iterable[Variable], args: Dict[Variable, Any], executor: Op
         if executor is not None and var.op.thread_safe:
             cache[var] = executor.submit(var.op, *pos_args, **kw_args)
         else:
-            cache[var] = var.op(*pos_args, **kw_args)
+            try:
+                cache[var] = var.op(*pos_args, **kw_args)
+            except Exception as err:
+                raise RuntimeError(f"Evaluating the variable {var} failed.") from err
 
     return [cache[var].result() if isinstance(cache[var], Future) else cache[var] for var in output]
 

--- a/paragraph/tests/test_types.py
+++ b/paragraph/tests/test_types.py
@@ -15,8 +15,11 @@ class MockReq(Requirement):
         super().merge(other)
 
 
-def mock_op(name="") -> Op:
-    operation = op(MagicMock(__name__=name, return_value=f"{name}_return_value"))
+def mock_op(name="", exception=None) -> Op:
+    if exception is not None:
+        operation = op(MagicMock(__name__=name, return_value=f"{name}_return_value", side_effect=exception))
+    else:
+        operation = op(MagicMock(__name__=name, return_value=f"{name}_return_value"))
     operation.arg_requirements = MagicMock(return_value=MockReq("Arg requirement"))
 
     return operation


### PR DESCRIPTION
This changeset ensures that a meaningful exception is raised when the
execution of an operation raises an exception during evaluation. In such
a case, a RuntimeError is raised with the original exception set as its
direct cause.